### PR TITLE
fix(jvim-timer): move timer file to persistent ~/.vim directory

### DIFF
--- a/jvim-timer/README.md
+++ b/jvim-timer/README.md
@@ -6,7 +6,7 @@
 
   [![EN](https://img.shields.io/badge/English-🇬🇧-blue)](#english)
   [![RU](https://img.shields.io/badge/Русский-🇷🇺-red)](#russian)
-  ![Version 0.1.0](https://img.shields.io/badge/Version-0.1.0-orange.svg)
+  ![Version 0.1.1](https://img.shields.io/badge/Version-0.1.0-orange.svg)
   ![Stars](https://img.shields.io/github/stars/AlexandrAnatoliev/jvim-plugins.svg?style=flat)
   ![Forks](https://img.shields.io/github/forks/AlexandrAnatoliev/jvim-plugins.svg?style=flat)
   ![GitHub repo size](https://img.shields.io/github/repo-size/AlexandrAnatoliev/jvim-plugins)
@@ -28,8 +28,9 @@
             └── jvim-timer/
                 ├── plugin/
                 │   └── jvim_timer.vim
-                └── java/
-                    └── JvimTimer.java
+                ├── java/
+                │   └── JvimTimer.java
+                └── data/
 ```
 
 * Compile the Java file:
@@ -56,7 +57,7 @@ $ vim example.md
 * After finishing work and closing Vim, 
 the following will be displayed:
 ```
-$ Время работы Vim: 310,4 секунд
+$ Время работы Vim: ... ч ... мин ... сек
 ```
 
 <div align="center">
@@ -81,7 +82,7 @@ $ Время работы Vim: 310,4 секунд
 
   [![EN](https://img.shields.io/badge/English-🇬🇧-blue)](#english)
   [![RU](https://img.shields.io/badge/Русский-🇷🇺-red)](#russian)
-  ![Version 0.1.0](https://img.shields.io/badge/Version-0.1.0-orange.svg)
+  ![Version 0.1.1](https://img.shields.io/badge/Version-0.1.0-orange.svg)
   ![Stars](https://img.shields.io/github/stars/AlexandrAnatoliev/jvim-plugins.svg?style=flat)
   ![Forks](https://img.shields.io/github/forks/AlexandrAnatoliev/jvim-plugins.svg?style=flat)
   ![GitHub repo size](https://img.shields.io/github/repo-size/AlexandrAnatoliev/jvim-plugins)
@@ -102,8 +103,9 @@ $ Время работы Vim: 310,4 секунд
             └── jvim-timer/
                 ├── plugin/
                 │   └── jvim_timer.vim
-                └── java/
-                    └── JvimTimer.java
+                ├── java/
+                │   └── JvimTimer.java
+                └── data/
 ```
 
 * Скомпилировать Java файл:
@@ -129,7 +131,7 @@ $ vim example.md
 
 * По окончании работы и закрытия Vim будет выведено:
 ```
-$ Время работы Vim: 310,4 секунд
+$ Время работы Vim: ... ч ... мин ... сек
 ```
 
 <div align="center">

--- a/jvim-timer/java/JvimTimer.java
+++ b/jvim-timer/java/JvimTimer.java
@@ -8,14 +8,15 @@ import java.time.*;
 * calculates running duration, outputs the result 
 * and deletes the temporary file 
 *
-* @version 0.1.0
+* @version 0.1.1 29.08.2025
 * @autor AlexandrAnatoliev
 */
 public class JvimTimer {
   public static void main(String[] args) {
     try {
       BufferedReader reader = 
-        new BufferedReader(new FileReader("/tmp/vim_start_time.txt"));
+        new BufferedReader(new FileReader(System.getenv("HOME") + 
+        "/.vim/pack/my-plugins/start/jvim-timer/data/vim_start_time.txt"));
       long startTime = Long.parseLong(reader.readLine());
       reader.close();
             
@@ -27,7 +28,9 @@ public class JvimTimer {
       System.out.printf("Время работы Vim: %d ч %d мин %d сек",
                         hours, minutes, seconds);
             
-      new File("/tmp/vim_start_time.txt").delete();
+      new File(System.getenv("HOME") +
+      "/.vim/pack/my-plugins/start/jvim-timer/data/vim_start_time.txt")
+      .delete();
             
     } catch (Exception e) {
         System.out.println("Ошибка таймера: " + e.getMessage());

--- a/jvim-timer/plugin/jvim_timer.vim
+++ b/jvim-timer/plugin/jvim_timer.vim
@@ -2,8 +2,8 @@
 " File: jvim_timer.vim
 " Description: Simple Vim work time measurement plugin 
 " Autor: AlexandAnatoliev
-" Version: 0.1.0
-" Last Modified: 27.08.25
+" Version: 0.1.1
+" Last Modified: 29.08.2025
 " ==================================================================
 
 " Automatic timer start on Vim enter and stop on Vim leave
@@ -17,8 +17,8 @@ autocmd VimLeave * call StopTimer()
 " Returns: None
 " ------------------------------------------------------------------  
 function! StartTimer()
-    silent !echo "" > /tmp/vim_start_time.txt
-    silent !date +\%s\%3N > /tmp/vim_start_time.txt
+    silent !echo "" > ~/.vim/pack/my-plugins/start/jvim-timer/data/vim_start_time.txt
+    silent !date +\%s\%3N > ~/.vim/pack/my-plugins/start/jvim-timer/data/vim_start_time.txt
 endfunction
 
 " ------------------------------------------------------------------  


### PR DESCRIPTION
- Change storage from /tmp/ to ~/.vim/pack/my-plugins/start/jvim-timer/data/
- Use proper home directory path resolution in Java
- Ensure timer data persists across system reboots

version 0.1.1